### PR TITLE
Add read only option 

### DIFF
--- a/_extensions/pyodide/qpyodide-cell-classes.js
+++ b/_extensions/pyodide/qpyodide-cell-classes.js
@@ -247,7 +247,8 @@ class InteractiveCell extends BaseCell {
                     },
                     fontSize: '17.5pt',              // Bootstrap is 1 rem
                     renderLineHighlight: "none",     // Disable current line highlighting
-                    hideCursorInOverviewRuler: true  // Remove cursor indictor in right hand side scroll bar
+                    hideCursorInOverviewRuler: true,  // Remove cursor indictor in right hand side scroll bar
+                    readOnly: thiz.options['read-only'] ?? false
                 }
             );
         

--- a/_extensions/pyodide/qpyodide.lua
+++ b/_extensions/pyodide/qpyodide.lua
@@ -45,6 +45,7 @@ local qPyodideDefaultCellOptions = {
   ["warning"] = "true",
   ["message"] = "true",
   ["results"] = "markup",
+  ["read-only"] = "false",
   ["output"] = "true",
   ["comment"] = "",
   ["label"] = "",

--- a/docs/qpyodide-code-cell-demo.qmd
+++ b/docs/qpyodide-code-cell-demo.qmd
@@ -82,6 +82,28 @@ print("Hello quarto-pyodide World!")
 
 By using these shortcuts, you can run code conveniently and efficiently. This practice can also help you become familiar with keyboard shortcuts when transitioning to integrated development environments (IDEs) like [RStudio](https://posit.co/products/open-source/rstudio/) or [Visual Studio Code with Python](https://code.visualstudio.com/docs/languages/python).
 
+
+## Preventing Modifications to Code
+
+Code cells can be locked to their initial state by specifying `#| read-only: true`. 
+
+::: {.panel-tabset}
+## `{quarto-pyodide}` Output
+
+```{pyodide-python}
+#| read-only: true
+1 + 1
+```
+
+## Cell code
+
+```{{pyodide-python}}
+#| read-only: true
+1 + 1
+```
+:::
+
+
 ## Define and Call Functions
 
 Functions can be defined in one cell and called. 
@@ -99,6 +121,7 @@ Similarly, they persist to other cells.
 num_list = [1, 2, 3]
 [square(num)for num in num_list]
 ```
+
 
 ## Load a package
 

--- a/docs/qpyodide-release-notes.qmd
+++ b/docs/qpyodide-release-notes.qmd
@@ -12,6 +12,14 @@ format:
 [python]: https://www.python.org/
 [quarto]: https://quarto.org/
 
+
+# 0.0.1.dev-1: What does the Python Say? (??-??-????)
+
+## Features
+
+- New code cell option that set the interactive cell to be read-only. ([#4](https://github.com/coatless-quarto/pyodide/issues/4))
+
+
 # 0.0.1: What does the Python Say? (02-19-2024)
 
 ## Features

--- a/tests/qpyodide-test-internal-cell.qmd
+++ b/tests/qpyodide-test-internal-cell.qmd
@@ -9,8 +9,16 @@ Test page for verifying cell context options set explicitly with `context`.
 
 ## Interactive
 
+### Editable
 ```{pyodide-python}
 #| context: interactive
+1 + 1
+```
+
+### Read-only
+```{pyodide-python}
+#| context: interactive
+#| read-only: true
 1 + 1
 ```
 


### PR DESCRIPTION
Enables the `read-only` option for the editor. We currently require users to press the "Run code" button to generate results. 

The option is accessible with: 

````md
```{pyodide-python}
#| read-only: true

1 + 1
```
````

<img width="634" alt="Example of the new `read-only` option in use." src="https://github.com/coatless-quarto/pyodide/assets/833642/67dd6dd0-c8a4-431f-9cd9-a23d7160ef59">

Close #4 